### PR TITLE
[Feature] Allow to handle parameters which have declared as ref

### DIFF
--- a/src/Command/Generate.php
+++ b/src/Command/Generate.php
@@ -148,6 +148,20 @@ class Generate extends \Symfony\Component\Console\Command\Command
 
         $twig->addFunction(
             new \Twig_Function(
+                'flowParameterWithRef',
+                function (\Swagger\Annotations\Parameter $parameter) use ($swagger) {
+                    $stripped = stripParameters($parameter->ref);
+                    foreach ($swagger->parameters as $param) {
+                        if ($stripped === $param->name) {
+                            return $param;
+                        }
+                    }
+                }
+            )
+        );
+
+        $twig->addFunction(
+            new \Twig_Function(
                 'makePath',
                 function (\Swagger\Annotations\Operation $operation) {
                     $path = $operation->path;

--- a/src/resource/js/params.twig
+++ b/src/resource/js/params.twig
@@ -3,7 +3,8 @@ export type {{ operationId }}Params = {
 {% for parameter in parameters %}
 {% if parameter.in != "path" and parameter.in != "body" %}
 {% if parameter.ref %}
-    {{ parameter.ref[13:]|flowFieldEscape|raw }}{{ parameter.required ? ':' : '?:' }} {{ flowParameterType(parameter)|raw }},
+{% set param = flowParameterWithRef(parameter) %}
+    {{ param.name|flowFieldEscape|raw }}{{ param.required ? ':' : '?:' }} {{ flowParameterType(parameter)|raw }},
 {% else %}
     {{ parameter.name|flowFieldEscape|raw }}{{ parameter.required ? ':' : '?:' }} {{ flowParameterType(parameter)|raw }},
 {% endif %}

--- a/src/resource/js/params.twig
+++ b/src/resource/js/params.twig
@@ -2,7 +2,11 @@
 export type {{ operationId }}Params = {
 {% for parameter in parameters %}
 {% if parameter.in != "path" and parameter.in != "body" %}
+{% if parameter.ref %}
+    {{ parameter.ref[13:]|flowFieldEscape|raw }}{{ parameter.required ? ':' : '?:' }} {{ flowParameterType(parameter)|raw }},
+{% else %}
     {{ parameter.name|flowFieldEscape|raw }}{{ parameter.required ? ':' : '?:' }} {{ flowParameterType(parameter)|raw }},
+{% endif %}
 {% endif %}
 {% endfor %}
 }


### PR DESCRIPTION
Hey, @ovr!

I want to extend functional for this tool. And i want to add handling of parameters, which declared as`ref`. I have a example to simplify understand for what this feature do.

**TL;DR** Properly handling swagger definitions, which have a following view: ` @SWG\Parameter(ref="#/parameters/fields")`

For example i have definitions for fields `fields`, which i will reuse in other definitions (i.e. in many other places)

```php
/**
 *  @SWG\Parameter(
 *    name="fields",
 *    type="string",
 *    in="query",
 *    description="description"
 *  )
 */
```

Usage:

```php
/**
 * @SWG\Get(
 *  tags={"Tags"},
 *  path="path",
 *  operationId="operationId",
 *  @SWG\Parameter(ref="#/parameters/fields"),
 * )
 */
```

**Expected output will be:**
```js
fields?: string
```

**Actual output:** (because it's not handling properly)
```js
?:
```

Thanks, and have a nice day!